### PR TITLE
README: add whitepaper link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ It meets best of breed expectations:
  * Atomic transactions to maintain consistent persistent structures
  * First class kernel implementation for high performance and low latency
  * Open GPLv2 implementation
+ 
+Learn more in the [white paper](https://docs.wixstatic.com/ugd/aaa89b_88a5cc84be0b4d1a90f60d8900834d28.pdf).
 
 # Current Status
 


### PR DESCRIPTION
The white paper is helpful and not linked from the Github README which will be a primary landing spot for folks discovering the project.