### PR TITLE
scoutfs: add setattr_more ioctl

### DIFF
--- a/src/count.h
+++ b/src/count.h
@@ -313,4 +313,19 @@ static inline const struct scoutfs_item_count SIC_FALLOCATE_ONE(void)
 	return cnt;
 }
 
+/*
+ * ioc_setattr_more can dirty the inode and add a single offline extent.
+ */
+static inline const struct scoutfs_item_count SIC_SETATTR_MORE(void)
+{
+	struct scoutfs_item_count cnt = {0,};
+
+	__count_dirty_inode(&cnt);
+
+	cnt.items++;
+	cnt.vals += sizeof(struct scoutfs_file_extent);
+
+	return cnt;
+}
+
 #endif

--- a/src/data.h
+++ b/src/data.h
@@ -45,6 +45,8 @@ int scoutfs_data_truncate_items(struct super_block *sb, struct inode *inode,
 int scoutfs_data_fiemap(struct inode *inode, struct fiemap_extent_info *fieinfo,
 			u64 start, u64 len);
 long scoutfs_fallocate(struct file *file, int mode, loff_t offset, loff_t len);
+int scoutfs_data_init_offline_extent(struct inode *inode, u64 size,
+				     struct scoutfs_lock *lock);
 
 int scoutfs_data_wait_check(struct inode *inode, loff_t pos, loff_t len,
 			    u8 sef, u8 op, struct scoutfs_data_wait *ow,

--- a/src/inode.c
+++ b/src/inode.c
@@ -540,6 +540,17 @@ void scoutfs_inode_inc_data_version(struct inode *inode)
 	preempt_enable();
 }
 
+void scoutfs_inode_set_data_version(struct inode *inode, u64 data_version)
+{
+	struct scoutfs_inode_info *si = SCOUTFS_I(inode);
+
+	preempt_disable();
+	write_seqcount_begin(&si->seqcount);
+	si->data_version = data_version;
+	write_seqcount_end(&si->seqcount);
+	preempt_enable();
+}
+
 void scoutfs_inode_add_onoff(struct inode *inode, s64 on, s64 off)
 {
 	struct scoutfs_inode_info *si;

--- a/src/inode.h
+++ b/src/inode.h
@@ -103,6 +103,7 @@ struct inode *scoutfs_new_inode(struct super_block *sb, struct inode *dir,
 void scoutfs_inode_set_meta_seq(struct inode *inode);
 void scoutfs_inode_set_data_seq(struct inode *inode);
 void scoutfs_inode_inc_data_version(struct inode *inode);
+void scoutfs_inode_set_data_version(struct inode *inode, u64 data_version);
 void scoutfs_inode_add_onoff(struct inode *inode, s64 on, s64 off);
 u64 scoutfs_inode_meta_seq(struct inode *inode);
 u64 scoutfs_inode_data_seq(struct inode *inode);

--- a/src/ioctl.h
+++ b/src/ioctl.h
@@ -253,4 +253,22 @@ struct scoutfs_ioctl_data_waiting {
 #define SCOUTFS_IOC_DATA_WAITING _IOW(SCOUTFS_IOCTL_MAGIC, 9, \
 				      struct scoutfs_ioctl_data_waiting)
 
+/*
+ * If i_size is set then data_version must be non-zero.  If the offline
+ * flag is set then i_size must be set and a offline extent will be
+ * created from offset 0 to i_size.
+ */
+struct scoutfs_ioctl_setattr_more {
+	__u64 data_version;
+	__u64 i_size;
+	__u64 flags;
+	struct scoutfs_timespec ctime;
+} __packed;
+
+#define SCOUTFS_IOC_SETATTR_MORE_OFFLINE		(1 << 0)
+#define SCOUTFS_IOC_SETATTR_MORE_UNKNOWN		(U8_MAX << 1)
+
+#define SCOUTFS_IOC_SETATTR_MORE _IOW(SCOUTFS_IOCTL_MAGIC, 10, \
+				      struct scoutfs_ioctl_setattr_more)
+
 #endif


### PR DESCRIPTION
Add an ioctl that can be used by userspace to restore a file to its
offline state.  To do that it needs to set inode fields that are
otherwise not exposed and create an offline extent.

Signed-off-by: Zach Brown <zab@versity.com>