### PR TITLE
scoutfs: naturally align ioctl structs

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -52,6 +52,24 @@ do {									\
 	__entry->name##_zone, __entry->name##_first, __entry->name##_type, \
 	__entry->name##_second, __entry->name##_third, __entry->name##_fourth
 
+/*
+ * copy fields between keys with the same fields but different types.
+ * The destination type might have internal padding so we zero it.
+ */
+#define scoutfs_key_copy_types(a, b)		\
+do {						\
+	__typeof__(a) _to = (a);		\
+	__typeof__(b) _from = (b);		\
+						\
+	memset(_to, 0, sizeof(*_to));		\
+	_to->sk_zone = _from->sk_zone;		\
+	_to->_sk_first = _from->_sk_first;	\
+	_to->sk_type = _from->sk_type;		\
+	_to->_sk_second = _from->_sk_second;	\
+	_to->_sk_third = _from->_sk_third;	\
+	_to->_sk_fourth = _from->_sk_fourth;	\
+} while (0)
+
 static inline void scoutfs_key_set_zeros(struct scoutfs_key *key)
 {
 	key->sk_zone = 0;


### PR DESCRIPTION
Order the ioctl struct field definitions and add padding so that
runtimes with different word dizes don't add different padding.
Userspace is spared having to deal with packing and we don't
have to worry about compat translation in the kernel.

We had two persistent structures that crossed the ioctl, a key and a
timespec, so we explicitly translate to and from their persistent types
in the ioctl.

Signed-off-by: Zach Brown <zab@versity.com>