### PR TITLE
scoutfs: fix setattr offline extent length

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -1572,7 +1572,7 @@ int scoutfs_data_init_offline_extent(struct inode *inode, u64 size,
 		if (ret < 0)
 			goto out;
 
-		count = min(blocks, last_iblock(iblock) - iblock + 1);
+		count = min(blocks - iblock, last_iblock(iblock) - iblock + 1);
 
 		ret = set_extent(sb, inode, ino, unpe, iblock, 0, count,
 				 SEF_OFFLINE);


### PR DESCRIPTION
We miscalculated the length of extents to create when initializing
offline extents for setattr_more.  We were clamping the extent length in
each packed extent item by the full size of the offline extent, ignoring
the iblock position that we were starting from.

Signed-off-by: Zach Brown <zab@versity.com>