### PR TITLE
scoutfs: fix older kc readdir emit

### DIFF
--- a/src/dir.c
+++ b/src/dir.c
@@ -500,7 +500,7 @@ static int KC_DECLARE_READDIR(scoutfs_readdir, struct file *file,
 		pos = le64_to_cpu(key.skd_major);
 		kc_readdir_pos(file, ctx) = pos;
 
-		if (!kc_dir_emit(ctx, dent, dent->name, name_len, pos,
+		if (!kc_dir_emit(ctx, dirent, dent->name, name_len, pos,
 				le64_to_cpu(dent->ino),
 				dentry_type(dent->type))) {
 			ret = 0;

--- a/src/kernelcompat.h
+++ b/src/kernelcompat.h
@@ -8,15 +8,15 @@ typedef filldir_t kc_readdir_ctx_t;
 #define KC_FOP_READDIR readdir
 #define kc_readdir_pos(filp, ctx) (filp)->f_pos
 #define kc_dir_emit_dots(file, dirent, ctx) dir_emit_dots(file, dirent, ctx)
-#define kc_dir_emit(ctx, dentry, name, name_len, pos, ino, dt) \
-	(ctx(dentry, name, name_len, pos, ino, dt) == 0)
+#define kc_dir_emit(ctx, dirent, name, name_len, pos, ino, dt) \
+	(ctx(dirent, name, name_len, pos, ino, dt) == 0)
 #else
 typedef struct dir_context * kc_readdir_ctx_t;
 #define KC_DECLARE_READDIR(name, file, dirent, ctx) name(file, ctx)
 #define KC_FOP_READDIR iterate
 #define kc_readdir_pos(filp, ctx) (ctx)->pos
 #define kc_dir_emit_dots(file, dirent, ctx) dir_emit_dots(file, ctx)
-#define kc_dir_emit(ctx, dentry, name, name_len, pos, ino, dt) \
+#define kc_dir_emit(ctx, dirent, name, name_len, pos, ino, dt) \
 	dir_emit(ctx, name, name_len, ino, dt)
 #endif
 


### PR DESCRIPTION
When we added the kernelcompat layer around the old and new readdir
interfaces there was some confusion in the old readdir interface filldir
arguments.  We were passing in our scoutfs dent item struct pointer
instead of the filldir callback buf pointer.  This prevented readdir
from working in older kernels because filldir would immediately see a
corrupt buf and return an error.

This renames the emit compat macro arguments to make them consistent
with the other calls and readdir now provides the correct pointer to the
emit wrapper.

Signed-off-by: Zach Brown <zab@versity.com>