### PR TITLE
stage_err - add support for reporting staging errors to data waiters

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -28,12 +28,14 @@ struct scoutfs_data_wait {
 	u64 chg;
 	u64 ino;
 	u64 iblock;
+	long err;
 	u8 op;
 };
 
 #define DECLARE_DATA_WAIT(nm)						\
 	struct scoutfs_data_wait nm = {					\
 		.node.__rb_parent_color = (unsigned long)(&nm.node),	\
+		.err = 0,						\
 	}
 
 struct scoutfs_traced_extent {
@@ -68,6 +70,8 @@ bool scoutfs_data_wait_found(struct scoutfs_data_wait *ow);
 int scoutfs_data_wait(struct inode *inode,
 			      struct scoutfs_data_wait *ow);
 void scoutfs_data_wait_changed(struct inode *inode);
+long scoutfs_data_stage_err(struct inode *inode, u64 sblock, u64 eblock,
+			    long err);
 int scoutfs_data_waiting(struct super_block *sb, u64 ino, u64 iblock,
 			 struct scoutfs_ioctl_data_waiting_entry *dwe,
 			 unsigned int nr);

--- a/src/ioctl.h
+++ b/src/ioctl.h
@@ -346,5 +346,20 @@ struct scoutfs_ioctl_statfs_more {
 #define SCOUTFS_IOC_STATFS_MORE _IOR(SCOUTFS_IOCTL_MAGIC, 10, \
 				     struct scoutfs_ioctl_statfs_more)
 
+/*
+ * Cause the offline data waiters within the specified range to report an error.
+ *
+ * Given the offline data waiter with inode version @version, cause any offline
+ * data waiters in the @start_offset to @end_offset byte range to return @err.
+ */
+struct scoutfs_ioctl_stage_err {
+	__u64 data_version;
+	__u64 start_offset;
+	__u64 end_offset;
+	__s64 err;
+};
+
+#define SCOUTFS_IOC_STAGE_ERR _IOW(SCOUTFS_IOCTL_MAGIC, 11, \
+				   struct scoutfs_ioctl_stage_err)
 
 #endif

--- a/src/scoutfs_trace.h
+++ b/src/scoutfs_trace.h
@@ -556,6 +556,35 @@ TRACE_EVENT(scoutfs_ioc_stage,
 		  __entry->offset, __entry->count)
 );
 
+TRACE_EVENT(scoutfs_ioc_stage_err,
+	TP_PROTO(struct super_block *sb, u64 ino,
+		 struct scoutfs_ioctl_stage_err *args),
+
+	TP_ARGS(sb, ino, args),
+
+	TP_STRUCT__entry(
+		SCSB_TRACE_FIELDS
+		__field(__u64, ino)
+		__field(__u64, vers)
+		__field(__u64, start_offset)
+		__field(__u64, end_offset)
+		__field(__s64, err)
+	),
+
+	TP_fast_assign(
+		SCSB_TRACE_ASSIGN(sb);
+		__entry->ino = ino;
+		__entry->vers = args->data_version;
+		__entry->start_offset = args->start_offset;
+		__entry->end_offset = args->end_offset;
+		__entry->err = args->err;
+	),
+
+	TP_printk(SCSBF" ino %llu vers %llu start %llu end %llu err %lld",
+		  SCSB_TRACE_ARGS, __entry->ino, __entry->vers,
+		  __entry->start_offset, __entry->end_offset, __entry->err)
+);
+
 DEFINE_EVENT(scoutfs_ino_ret_class, scoutfs_ioc_stage_ret,
 	TP_PROTO(struct super_block *sb, u64 ino, int ret),
 	TP_ARGS(sb, ino, ret)


### PR DESCRIPTION
Add support for reporting staging errors to offline data waiters via a
new SCOUTFS_IOC_STAGE_ERR ioctl.  This allows waiters to return an
error to readers when staging fails.

Signed-off-by: Benjamin LaHaise <bcrl@kvack.org>